### PR TITLE
Disable Jekyll for GitHub Pages demo

### DIFF
--- a/astro-demo/README.md
+++ b/astro-demo/README.md
@@ -12,3 +12,11 @@ npm install
 npm run dev
 npm run build
 ```
+
+## GitHub Pages note
+
+This repository currently uses classic GitHub Pages from `master` at `/`, not a GitHub Actions Astro deployment.
+
+That is intentional for this prototype: Astro is used to generate static files into `/demo`, and GitHub Pages publishes those already-built files.
+
+The root `.nojekyll` file is required because otherwise GitHub Pages tries to process the entire repository with Jekyll and fails on Astro source files such as `src/pages/index.astro`.


### PR DESCRIPTION
## Summary
- Adds a root `.nojekyll` file so GitHub Pages publishes static files directly
- Documents why this repo can contain Astro source while still using classic GitHub Pages

## Why
GitHub Pages currently tries to run Jekyll over the whole repo and fails on Astro source files like `astro-demo/src/pages/index.astro`.

This setup is supported because Astro builds static output into `/demo`; GitHub Pages only needs to serve that static output.

## Verification
- Confirmed PR #3 is merged
- Confirmed latest Pages deployment failed during Jekyll processing
- Astro docs support deploying Astro to GitHub Pages; this repo is using a prebuilt-static variant rather than Actions-based deployment
